### PR TITLE
Enforce location of script tag in cat-picture lesson.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "adventure": "^2.11.0",
     "ansimd": "^0.2.1",
     "chalk": "^1.1.1",
+    "cheerio": "^0.20.0",
     "which": "^1.2.4"
   },
   "devDependencies": {

--- a/problems/cat_picture/index.js
+++ b/problems/cat_picture/index.js
@@ -2,6 +2,7 @@ var fs = require('fs')
 var path = require('path')
 var chalk = require('chalk')
 var mdrender = require('../../markdown-render.js')
+var cheerio = require('cheerio')
 
 module.exports = function () {
   var problem = {}
@@ -18,6 +19,21 @@ module.exports = function () {
       console.error('\nFailed to find index.js, package.json with cat-picture in dependencies and the folder ./node_modules/cat_picture')
       return cb(false)
     }
+
+    try {
+      var html = fs.readFileSync(path.join(process.cwd(), 'index.html')).toString()
+      var $ = cheerio.load(html)
+      var script = $('script')
+      var body = $('body')
+      if (!$.contains(body, script)) {
+        console.error('\nThe script tag should be in the body of your html document!')
+        return cb(false)
+      }
+    } catch (e) {
+      console.error('There was a problem reading your index.html file!')
+      return cb(false)
+    }
+
     cb(true)
   }
 


### PR DESCRIPTION
When I went through this workshop, I passed this test but it didn't render the cat picture.

That's because I'd skimmed the instructions and hadn't put the script tag in the body.

This now catches that problem and hints the user!
