### PR TITLE
Update install instructions to use electron module

### DIFF
--- a/exercises/installing/problem.en.md
+++ b/exercises/installing/problem.en.md
@@ -2,7 +2,7 @@
 
 You have to install `electron` into your command line environment.
 
-Run `npm install electron-prebuilt -g`
+Run `npm install electron -g`
 
 If you receive an EACCES error read this guide:
 


### PR DESCRIPTION
According to [this post](http://electron.atom.io/blog/2016/08/16/npm-install-electron) and [the quickstart doc](http://electron.atom.io/docs/tutorial/quick-start/) `electron` is now the preferred module to install electron.