### PR TITLE
fix: add webPreferences: { nodeIntegration: true, enableRemoteModule: true } to BrowserWindow options

### DIFF
--- a/exercises/hello_world/problem.en.md
+++ b/exercises/hello_world/problem.en.md
@@ -23,7 +23,7 @@ Then create a file (in the same folder) called `app.js` with the following conte
 var electron = require('electron')
 
 electron.app.on('ready', function () {
-  var mainWindow = new electron.BrowserWindow({width: 600, height: 800})
+  var mainWindow = new electron.BrowserWindow({width: 600, height: 800, webPreferences: { nodeIntegration: true, enableRemoteModule: true }})
   mainWindow.loadURL('file://' + __dirname + '/index.html')
 })
 ```

--- a/exercises/hello_world/problem.ja.md
+++ b/exercises/hello_world/problem.ja.md
@@ -23,7 +23,7 @@
 var electron = require('electron')
 
 electron.app.on('ready', function () {
-  var mainWindow = new electron.BrowserWindow({width: 600, height: 800})
+  var mainWindow = new electron.BrowserWindow({width: 600, height: 800, webPreferences: { nodeIntegration: true, enableRemoteModule: true }})
   mainWindow.loadURL('file://' + __dirname + '/index.html')
 })
 ```

--- a/exercises/hello_world/problem.ko.md
+++ b/exercises/hello_world/problem.ko.md
@@ -24,7 +24,7 @@
 var electron = require('electron')
 
 electron.app.on('ready', function () {
-  var mainWindow = new electron.BrowserWindow({width: 600, height: 800})
+  var mainWindow = new electron.BrowserWindow({width: 600, height: 800, webPreferences: { nodeIntegration: true, enableRemoteModule: true }})
   mainWindow.loadURL('file://' + __dirname + '/index.html')
 })
 ```


### PR DESCRIPTION
The `webPreferences` settings for `nodeIntegration` and `enableRemoteModule` are by default set to `false`, preventing access to modules needed to complete the workshopper.  Updating settings to `true` to allow access to modules.

Pull request includes changes by @BackgroundLogic from #34 and by @EngineerDogIta from #37 